### PR TITLE
Change for compiling GEOSX with Trilinos/Tpetra interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ set( componentHeaders "ParallelTopologyChange.hpp" )
 
 set( componentSources "ParallelTopologyChange.cpp" )
 
-set( dependencyList mesh )
+set( dependencyList mesh linearAlgebra )
 
 if ( ENABLE_OPENMP )
   set( dependencyList ${dependencyList} openmp )


### PR DESCRIPTION
This PR works around the following problem:

`ParallelTopologyChange.hpp` includes `SurfaceGenerator.hpp`. When GEOSX is compiled with `TrilinosTpetra` as selected LAI, it therefore transitively includes `TpetraVector` and `TpetraMatrix`, which include forward declaration headers from Tpetra. However, because PTP does not have either `linearAlgebra` or `physicsSolvers` as its dependency, BLT/Cmake does not place Trilinos install dir on its include paths, and the compiler fails to find those Tpetra headers. I simply added `linearAlgebra` as a dependency for now (adding `physicsSolvers` would create a circular dependency).

Couple notes:
1. This was not an issue with Epetra-based interface (or Hypre/Petsc) because we did not include any Epetra headers in `EpetraVector` or `EpetraMatrix`, instead simply forward declaring the types ourselves. This is significantly more difficult to do with Tpetra, because the types are templates with a bunch of default parameters that are defined deep in Tpetra headers at config time. It would be unwise for us to try replicate all those namespaces/types. Luckily, Tpetra provides forward declaration headers for every public type (e.g. `Tpetra_Vector_fwd.hpp`), and we *have to* include those.
2. This workaround is not great, because obviously PTP does *not* have a dependency on `linearAlgebra`. Root of the issue is that it includes `SurfaceGenerator.hpp` *only* for the definition of `ModifiedObjectLists`. A better solution would be to put `ModifiedObjectLists` in its own header and forward declare it in both of the above. Or at least move definition to `ParallelTopologyChange.hpp`. Let me know your preferences.

Related to https://github.com/GEOSX/GEOSX/pull/1086